### PR TITLE
Import metrics python3 compatible

### DIFF
--- a/surface_distance/__init__.py
+++ b/surface_distance/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 """Surface distance module: https://github.com/deepmind/surface-distance ."""
 
-from metrics import *  # pylint: disable=wildcard-import
+from __future__ import absolute_import
+from .metrics import *  # pylint: disable=wildcard-import
 __version__ = "0.1"


### PR DESCRIPTION
Hey there,

I wanted to use your code to compute surface distance but one import was not python3 compatible. 
Here is a PR which sorts out this issue.

Cheers