### PR TITLE
Fix setup.py to have correct "name=" field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 
 from setuptools import setup
 
-setup(name="Surface Distance Based Measures",
+setup(name="surface_distance",
       version="0.1",
       description=(
           "Library containing utilities to compute performance metrics for "


### PR DESCRIPTION
It's not possible to import surface-distance as a dependency from pip, poetry, etc. because the package in setup.py is incorrectly defined.